### PR TITLE
feat: 관리자 상품 목록 조회 API 추가

### DIFF
--- a/team1/src/main/java/com/gdg/sprint/team1/controller/AdminProductController.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/AdminProductController.java
@@ -1,0 +1,42 @@
+package com.gdg.sprint.team1.controller;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.gdg.sprint.team1.common.ApiResponse;
+import com.gdg.sprint.team1.dto.product.ProductListResponse;
+import com.gdg.sprint.team1.service.ProductService;
+
+@RestController
+@RequestMapping("/api/v1/admin/products")
+@Validated
+@RequiredArgsConstructor
+public class AdminProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ProductListResponse>> getAdminProducts(
+            @RequestParam(required = false, defaultValue = "1") @Min(1) Integer page,
+            @RequestParam(required = false, defaultValue = "20") @Min(1) @Max(100) Integer limit,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String search
+    ) {
+        ProductListResponse data = productService.getAdminProductList(page, limit, status, search);
+
+        String message = data.pagination().totalItems() == 0
+                ? "검색 결과가 없습니다."
+                : "관리자 상품 목록 조회 성공";
+
+        return ResponseEntity.ok(ApiResponse.success(data, message));
+    }
+}

--- a/team1/src/main/java/com/gdg/sprint/team1/service/ProductService.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/service/ProductService.java
@@ -130,4 +130,14 @@ public class ProductService {
             default -> "createdAt";
         };
     }
+
+    @Transactional(readOnly = true)
+    public ProductListResponse getAdminProductList(
+            Integer page,
+            Integer limit,
+            String status,
+            String search
+    ) {
+        return getProductList(page, limit, status, search, null, null, null, null, null);
+    }
 }


### PR DESCRIPTION
## 변경 사항
- 관리자 상품 목록 조회 엔드포인트 추가: `GET /api/v1/admin/products`
- `AdminProductController` 신규 추가
- `ProductService#getAdminProductList` 메서드 추가
- 기존 `getProductList(...)` 로직을 재사용해 관리자 조회 조건(페이지/상태/검색) 처리
- 요청 파라미터 검증 적용: `page(@Min(1))`, `limit(@Min(1), @Max(100))`

## 관련 이슈
- #25 

## 체크리스트
- [x] 로컬에서 동작 확인
- [ ] (필요 시) 테스트 추가/통과
- [ ] 문서/주석 필요 시 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 관리자용 상품 목록 조회 API 추가: 페이지네이션 기능(기본값 1페이지, 최대 100개 항목) 및 상태와 검색 키워드를 통한 고급 필터링 옵션 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->