### PR TITLE
feat: 마이페이지 주문/쿠폰 조회 API 구현

### DIFF
--- a/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
@@ -2,7 +2,12 @@ package com.gdg.sprint.team1.controller;
 
 import java.util.List;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,18 +19,22 @@ import com.gdg.sprint.team1.common.ApiResponse;
 import com.gdg.sprint.team1.controller.api.MyPageApi;
 import com.gdg.sprint.team1.dto.auth.UserMeResponse;
 import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.order.OrderResponse;
 import com.gdg.sprint.team1.security.CurrentUser;
 import com.gdg.sprint.team1.security.UserContextHolder;
+import com.gdg.sprint.team1.service.OrderService;
 import com.gdg.sprint.team1.service.UserCouponService;
 import com.gdg.sprint.team1.service.UserService;
 
 @RestController
 @RequestMapping("/api/v1/my")
+@Validated
 @RequiredArgsConstructor
 public class MyPageController implements MyPageApi {
 
     private final UserService userService;
     private final UserCouponService userCouponService;
+    private final OrderService orderService;
 
     @Override
     @GetMapping("/info")
@@ -47,5 +56,18 @@ public class MyPageController implements MyPageApi {
             .map(MyCouponResponse::from)
             .toList();
         return ResponseEntity.ok(ApiResponse.success(data, "쿠폰 목록 조회 성공"));
+    }
+
+    @Override
+    @GetMapping("/orders")
+    public ResponseEntity<ApiResponse<Page<OrderResponse>>> getMyOrders(
+            @CurrentUser UserContextHolder.UserContext user,
+            @RequestParam(required = false, defaultValue = "1") @Min(1) Integer page,
+            @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(100) Integer limit,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Integer months
+    ) {
+        Page<OrderResponse> data = orderService.getMyOrders(user.userId(), page, limit, status, months);
+        return ResponseEntity.ok(ApiResponse.success(data, "주문 목록 조회 성공"));
     }
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +21,7 @@ import com.gdg.sprint.team1.common.ApiResponse;
 import com.gdg.sprint.team1.controller.api.MyPageApi;
 import com.gdg.sprint.team1.dto.auth.UserMeResponse;
 import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.order.OrderDetailResponse;
 import com.gdg.sprint.team1.dto.order.OrderResponse;
 import com.gdg.sprint.team1.security.CurrentUser;
 import com.gdg.sprint.team1.security.UserContextHolder;
@@ -69,5 +72,15 @@ public class MyPageController implements MyPageApi {
     ) {
         Page<OrderResponse> data = orderService.getMyOrders(user.userId(), page, limit, status, months);
         return ResponseEntity.ok(ApiResponse.success(data, "주문 목록 조회 성공"));
+    }
+
+    @Override
+    @GetMapping("/orders/{id}")
+    public ResponseEntity<ApiResponse<OrderDetailResponse>> getMyOrderDetail(
+            @CurrentUser UserContextHolder.UserContext user,
+            @PathVariable("id") @Positive Integer orderId
+    ) {
+        OrderDetailResponse data = orderService.getOrderDetail(user.userId(), orderId);
+        return ResponseEntity.ok(ApiResponse.success(data, "주문 상세 조회 성공"));
     }
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import com.gdg.sprint.team1.common.ApiResponse;
 import com.gdg.sprint.team1.dto.auth.UserMeResponse;
 import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.order.OrderDetailResponse;
 import com.gdg.sprint.team1.dto.order.OrderResponse;
 import com.gdg.sprint.team1.security.CurrentUser;
 import com.gdg.sprint.team1.security.UserContextHolder;
@@ -58,5 +60,19 @@ public interface MyPageApi {
                     allowableValues = {"PENDING", "CONFIRMED", "SHIPPING", "DELIVERED", "CANCELLED"}
             )) String status,
             @Parameter(description = "조회 기간(개월)", schema = @Schema(allowableValues = {"1", "3", "6"})) Integer months
+    );
+
+    @Operation(
+            summary = "내 주문 상세",
+            description = "내 주문 상세 정보(배송 정보 포함)를 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "주문 없음")
+    })
+    ResponseEntity<ApiResponse<OrderDetailResponse>> getMyOrderDetail(
+            @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
+            @Parameter(description = "주문 ID", example = "1") @Positive Integer orderId
     );
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
@@ -2,7 +2,18 @@ package com.gdg.sprint.team1.controller.api;
 
 import java.util.List;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+
+import com.gdg.sprint.team1.common.ApiResponse;
+import com.gdg.sprint.team1.dto.auth.UserMeResponse;
+import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.order.OrderResponse;
+import com.gdg.sprint.team1.security.CurrentUser;
+import com.gdg.sprint.team1.security.UserContextHolder;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,12 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import com.gdg.sprint.team1.common.ApiResponse;
-import com.gdg.sprint.team1.dto.auth.UserMeResponse;
-import com.gdg.sprint.team1.dto.my.MyCouponResponse;
-import com.gdg.sprint.team1.security.CurrentUser;
-import com.gdg.sprint.team1.security.UserContextHolder;
 
 @Tag(name = "마이페이지 API", description = "내 정보·쿠폰 조회 (JWT 인증 필요)")
 public interface MyPageApi {
@@ -35,5 +40,23 @@ public interface MyPageApi {
     ResponseEntity<ApiResponse<List<MyCouponResponse>>> getMyCoupons(
         @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
         @Parameter(description = "AVAILABLE: 사용가능, USED: 사용완료", schema = @Schema(allowableValues = {"AVAILABLE", "USED"})) String status
+    );
+
+    @Operation(
+            summary = "내 주문 목록",
+            description = "기간(1/3/6개월) + 상태 필터로 내 주문 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponse<Page<OrderResponse>>> getMyOrders(
+            @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
+            @Parameter(description = "페이지 번호 (기본: 1)", example = "1") @Min(1) Integer page,
+            @Parameter(description = "페이지당 항목 수 (기본: 10)", example = "10") @Min(1) @Max(100) Integer limit,
+            @Parameter(description = "주문 상태", schema = @Schema(
+                    allowableValues = {"PENDING", "CONFIRMED", "SHIPPING", "DELIVERED", "CANCELLED"}
+            )) String status,
+            @Parameter(description = "조회 기간(개월)", schema = @Schema(allowableValues = {"1", "3", "6"})) Integer months
     );
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
@@ -35,13 +35,13 @@ public interface MyPageApi {
         @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user
     );
 
-    @Operation(summary = "내 쿠폰 목록", description = "사용 가능/사용 완료 필터 (status=AVAILABLE | USED, 미지정 시 전체)", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "내 쿠폰 목록", description = "사용 가능/사용 완료 필터 (status=AVAILABLE | USED | EXPIRED, 미지정 시 전체)", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     })
     ResponseEntity<ApiResponse<List<MyCouponResponse>>> getMyCoupons(
         @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
-        @Parameter(description = "AVAILABLE: 사용가능, USED: 사용완료", schema = @Schema(allowableValues = {"AVAILABLE", "USED"})) String status
+        @Parameter(description = "AVAILABLE: 사용가능, USED: 사용완료, EXPIRED: 만료", schema = @Schema(allowableValues = {"AVAILABLE", "USED", "EXPIRED"})) String status
     );
 
     @Operation(

--- a/team1/src/main/java/com/gdg/sprint/team1/dto/my/MyCouponResponse.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/dto/my/MyCouponResponse.java
@@ -1,11 +1,12 @@
 package com.gdg.sprint.team1.dto.my;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 import com.gdg.sprint.team1.entity.UserCoupon;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "마이페이지 보유 쿠폰 응답")
 public record MyCouponResponse(
@@ -32,9 +33,20 @@ public record MyCouponResponse(
     LocalDateTime usedAt,
 
     @Schema(description = "사용 가능 여부 (미사용·미만료)")
-    Boolean available
+    Boolean available,
+
+    @Schema(description = "만료까지 남은 일수 (만료/사용완료 시 0)")
+    Long expiresInDays
+
 ) {
     public static MyCouponResponse from(UserCoupon uc) {
+        boolean usable = uc.isUsable();
+        long days = 0L;
+        if (usable && uc.getExpiredAt() != null) {
+            days = java.time.temporal.ChronoUnit.DAYS.between(LocalDate.now(), uc.getExpiredAt().toLocalDate());
+            if (days < 0) days = 0L;
+        }
+
         return new MyCouponResponse(
             uc.getId(),
             uc.getCoupon().getName(),
@@ -43,7 +55,8 @@ public record MyCouponResponse(
             uc.getCoupon().getCouponType().name(),
             uc.getExpiredAt(),
             uc.getUsedAt(),
-            uc.isUsable()
+            usable,
+            days
         );
     }
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/repository/OrderRepository.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/repository/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.gdg.sprint.team1.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -26,4 +27,19 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
         "orderItems.product"
     })
     Optional<Order> findWithDetailsById(Integer orderId);
+
+    @EntityGraph(attributePaths = {"orderItems"})
+    Page<Order> findAllByUserIdAndCreatedAtGreaterThanEqual(
+            Integer userId,
+            LocalDateTime fromDate,
+            Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"orderItems"})
+    Page<Order> findAllByUserIdAndOrderStatusAndCreatedAtGreaterThanEqual(
+            Integer userId,
+            OrderStatus orderStatus,
+            LocalDateTime fromDate,
+            Pageable pageable
+    );
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/service/UserCouponService.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/service/UserCouponService.java
@@ -68,6 +68,8 @@ public class UserCouponService {
             stream = stream.filter(UserCoupon::isUsable);
         } else if ("USED".equalsIgnoreCase(status)) {
             stream = stream.filter(uc -> uc.getUsedAt() != null);
+        } else if ("EXPIRED".equalsIgnoreCase(status)) {
+            stream = stream.filter(uc -> uc.getUsedAt() == null && uc.getExpiredAt() != null && uc.getExpiredAt().isBefore(java.time.LocalDateTime.now()));
         }
         return stream.toList();
     }


### PR DESCRIPTION
## 변경 사항
- 마이페이지 주문 목록 API 추가: `GET /api/v1/my/orders`
  - 기간 필터(`months=1|3|6`) + 주문 상태 필터(`status`) + 페이징 지원
- 마이페이지 주문 상세 API 추가: `GET /api/v1/my/orders/{id}`
- 마이페이지 쿠폰 조회 확장: `GET /api/v1/my/coupons`
  - 상태 필터 `AVAILABLE | USED | EXPIRED` 지원
  - 응답 필드 `expiresInDays` 추가
- 관련 레이어 반영
  - `MyPageApi`, `MyPageController`
  - `OrderService`, `OrderRepository`
  - `MyCouponResponse`, `UserCouponService`

## 관련 이슈
- #26 

## 체크리스트
- [x] 로컬에서 동작 확인
- [ ] (필요 시) 테스트 추가/통과
- [ ] 문서/주석 필요 시 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 주문 목록 조회 API 추가 - 페이지네이션, 상태, 기간별 필터링 지원
  * 주문 상세 정보 조회 API 추가
  * 쿠폰 남은 유효 기한(일수) 표시 기능 추가
  * 만료된 쿠폰 필터링 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->