### PR TITLE
feat: 마이페이지 내 정보 수정 API 구현

### DIFF
--- a/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.gdg.sprint.team1.controller;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
@@ -10,10 +11,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +24,7 @@ import com.gdg.sprint.team1.common.ApiResponse;
 import com.gdg.sprint.team1.controller.api.MyPageApi;
 import com.gdg.sprint.team1.dto.auth.UserMeResponse;
 import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.my.UpdateMyInfoRequest;
 import com.gdg.sprint.team1.dto.order.OrderDetailResponse;
 import com.gdg.sprint.team1.dto.order.OrderResponse;
 import com.gdg.sprint.team1.security.CurrentUser;
@@ -28,6 +32,7 @@ import com.gdg.sprint.team1.security.UserContextHolder;
 import com.gdg.sprint.team1.service.OrderService;
 import com.gdg.sprint.team1.service.UserCouponService;
 import com.gdg.sprint.team1.service.UserService;
+import com.gdg.sprint.team1.entity.User;
 
 @RestController
 @RequestMapping("/api/v1/my")
@@ -82,5 +87,15 @@ public class MyPageController implements MyPageApi {
     ) {
         OrderDetailResponse data = orderService.getOrderDetail(user.userId(), orderId);
         return ResponseEntity.ok(ApiResponse.success(data, "주문 상세 조회 성공"));
+    }
+
+    @Override
+    @PatchMapping("/info")
+    public ResponseEntity<ApiResponse<UserMeResponse>> updateMyInfo(
+            @CurrentUser UserContextHolder.UserContext user,
+            @Valid @RequestBody UpdateMyInfoRequest request
+    ) {
+        User updated = userService.updateMyInfo(user.userId(), request);
+        return ResponseEntity.ok(ApiResponse.success(UserMeResponse.from(updated), "내 정보 수정 성공"));
     }
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/controller/api/MyPageApi.java
@@ -2,6 +2,7 @@ package com.gdg.sprint.team1.controller.api;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import com.gdg.sprint.team1.common.ApiResponse;
 import com.gdg.sprint.team1.dto.auth.UserMeResponse;
 import com.gdg.sprint.team1.dto.my.MyCouponResponse;
+import com.gdg.sprint.team1.dto.my.UpdateMyInfoRequest;
 import com.gdg.sprint.team1.dto.order.OrderDetailResponse;
 import com.gdg.sprint.team1.dto.order.OrderResponse;
 import com.gdg.sprint.team1.security.CurrentUser;
@@ -75,4 +77,19 @@ public interface MyPageApi {
             @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
             @Parameter(description = "주문 ID", example = "1") @Positive Integer orderId
     );
+
+    @Operation(
+            summary = "내 정보 수정",
+            description = "로그인 사용자의 이름/전화번호/주소를 부분 수정합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<ApiResponse<UserMeResponse>> updateMyInfo(
+            @Parameter(hidden = true) @CurrentUser UserContextHolder.UserContext user,
+            @Valid UpdateMyInfoRequest request
+    );
+
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/dto/my/UpdateMyInfoRequest.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/dto/my/UpdateMyInfoRequest.java
@@ -1,4 +1,29 @@
 package com.gdg.sprint.team1.dto.my;
 
-public class UpdateMyInfoRequest {
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 정보 수정 요청 (PATCH /api/v1/my/info)")
+public record UpdateMyInfoRequest (
+    @Size(max = 100, message = "이름은 최대 100자까지 입력 가능합니다.")
+    @Schema(description = "이름(선택)", example = "홍길동")
+    String name,
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)")
+    @Schema(description = "전화번호(선택)", example = "010-1234-5678")
+    String phone,
+
+    @Size(max = 500, message = "주소는 최대 500자까지 입력 가능합니다.")
+    @Schema(description = "주소(선택)", example = "서울특별시 강남구 테헤란로 123")
+    String address
+) {
+    public boolean hasAnyField() {
+        return hasText(name) || hasText(phone) || hasText(address);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
 }

--- a/team1/src/main/java/com/gdg/sprint/team1/dto/my/UpdateMyInfoRequest.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/dto/my/UpdateMyInfoRequest.java
@@ -1,0 +1,4 @@
+package com.gdg.sprint.team1.dto.my;
+
+public class UpdateMyInfoRequest {
+}

--- a/team1/src/main/java/com/gdg/sprint/team1/entity/User.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/entity/User.java
@@ -96,13 +96,23 @@ public class User {
 
     public void updateProfile(String name, String phone, String address) {
         if (name != null) {
-            this.name = name.trim();
+            String trimmedName = name.trim();
+            if (trimmedName.isEmpty()) {
+                throw new IllegalArgumentException("이름은 공백만 입력할 수 없습니다.");
+            }
+            this.name = trimmedName;
         }
         if (phone != null) {
-            this.phone = phone.trim();
+            String trimmedPhone = phone.trim();
+            if (!trimmedPhone.isEmpty()) {
+                this.phone = trimmedPhone;
+            }
         }
         if (address != null) {
-            this.address = address.trim();
+            String trimmedAddress = address.trim();
+            if (!trimmedAddress.isEmpty()) {
+                this.address = trimmedAddress;
+            }
         }
     }
 

--- a/team1/src/main/java/com/gdg/sprint/team1/entity/User.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/entity/User.java
@@ -94,6 +94,18 @@ public class User {
     public UserRole getRole() { return role; }
     public void setRole(UserRole role) { this.role = role; }
 
+    public void updateProfile(String name, String phone, String address) {
+        if (name != null) {
+            this.name = name.trim();
+        }
+        if (phone != null) {
+            this.phone = phone.trim();
+        }
+        if (address != null) {
+            this.address = address.trim();
+        }
+    }
+
     public enum UserRole {
         USER,
         ADMIN

--- a/team1/src/main/java/com/gdg/sprint/team1/service/UserService.java
+++ b/team1/src/main/java/com/gdg/sprint/team1/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.gdg.sprint.team1.dto.my.UpdateMyInfoRequest;
 import com.gdg.sprint.team1.entity.User;
 import com.gdg.sprint.team1.exception.UserNotFoundException;
 import com.gdg.sprint.team1.repository.UserRepository;
@@ -36,5 +37,16 @@ public class UserService {
     @Transactional
     public User save(User user) {
         return userRepository.save(user);
+    }
+
+    @Transactional
+    public User updateMyInfo(Integer userId, UpdateMyInfoRequest request) {
+        if (request == null || !request.hasAnyField()) {
+            throw new IllegalArgumentException("수정할 필드가 없습니다.");
+        }
+
+        User user = findById(userId);
+        user.updateProfile(request.name(), request.phone(), request.address());
+        return user;
     }
 }


### PR DESCRIPTION
## 변경 사항
- 로그인 사용자의 내 정보를 부분 수정할 수 있는 API 추가
  - `PATCH /api/v1/my/info`
- 수정 요청 DTO 추가
  - `UpdateMyInfoRequest` (name/phone/address)
  - 유효성 검증 적용 (`@Pattern`, `@Size`)
  - 빈/공백-only 요청 방지 (`hasAnyField`)
- 컨트롤러/서비스/엔티티 반영
  - `MyPageApi`, `MyPageController`에 수정 엔드포인트 연결
  - `UserService#updateMyInfo` 추가
  - `User#updateProfile` 추가 (null 아닌 필드만 부분 수정 + trim)

## 관련 이슈
- #31 

## 체크리스트
- [x] 로컬에서 동작 확인
- [ ] (필요 시) 테스트 추가/통과
- [ ] 문서/주석 필요 시 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에서 개인 정보(이름, 전화번호, 주소) 부분 수정 기능이 추가되었습니다.
  * 필요한 항목만 선택해 업데이트할 수 있으며, 미수정 정보는 유지됩니다.
  * 전화번호 및 입력값 검증이 포함되어 잘못된 값 입력을 방지합니다.
  * 수정 요청 시 업데이트된 사용자 정보가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->